### PR TITLE
feat: GET housing unit by ID and PATCH/POST for building and housing unit

### DIFF
--- a/src/main/java/dev/coms4156/project/kebabcase/controller/BuildingController.java
+++ b/src/main/java/dev/coms4156/project/kebabcase/controller/BuildingController.java
@@ -25,7 +25,12 @@ public class BuildingController {
 
   private final ObjectMapper objectMapper;
 
-
+  /**
+   * Constructs a new BuildingController.
+   * 
+   * @param buildingRepository the repository used to interact with building entities
+   * @param objectMapper the object mapper used for JSON serialization
+   */
   public BuildingController(
       BuildingRepositoryInterface buildingRepository,
       ObjectMapper objectMapper
@@ -34,6 +39,19 @@ public class BuildingController {
     this.objectMapper = objectMapper;
   }
 
+  /**
+   * Updates the information of an existing building by its ID.
+   * Only fields provided as request parameters will be updated.
+   * If no fields are provided, an HTTP 400 Bad Request will be returned.
+   * 
+   * @param id the ID of the building to update
+   * @param address the new address of the building (optional)
+   * @param city the new city of the building (optional)
+   * @param state the new state of the building (optional)
+   * @param zipCode the new zip code of the building (optional)
+   * @return a {@link ResponseEntity} indicating the result of the update
+   * @throws ResponseStatusException if the building with the given ID is not found or no fields are provided for update
+   */
   @PatchMapping("/building/{id}")
   public ResponseEntity<?> updateBuilding(
       @PathVariable int id, 
@@ -79,6 +97,16 @@ public class BuildingController {
 
   }
 
+  /**
+   * Creates a new building entity and saves it to the repository.
+   * The new building's information must be provided as request parameters.
+   * 
+   * @param address the address of the new building
+   * @param city the city of the new building
+   * @param state the state of the new building
+   * @param zipCode the zip code of the new building
+   * @return a {@link ResponseEntity} containing the result of the creation and the new building's ID
+   */
   @PostMapping("/building")
   public ResponseEntity<?> createBuilding(
       @RequestParam String address,

--- a/src/main/java/dev/coms4156/project/kebabcase/controller/BuildingController.java
+++ b/src/main/java/dev/coms4156/project/kebabcase/controller/BuildingController.java
@@ -129,11 +129,16 @@ public class BuildingController {
           invalidFeatures.add(featureID);
         } else {
           BuildingFeatureEntity feature = featureResult.get();
-        
-          buildingMapFeature.setBuilding(building);
-          buildingMapFeature.setBuildingFeature(feature);
 
-          buildingFeatureMappingRepository.save(buildingMapFeature);
+          Optional<BuildingFeatureBuildingMappingEntity> existingMapping =
+            this.buildingFeatureMappingRepository.findByBuildingAndBuildingFeature(building, feature);
+
+          if (existingMapping.isEmpty()) {
+            buildingMapFeature.setBuilding(building);
+            buildingMapFeature.setBuildingFeature(feature);
+
+            buildingFeatureMappingRepository.save(buildingMapFeature);
+          }
         }
       }
     }

--- a/src/main/java/dev/coms4156/project/kebabcase/controller/BuildingController.java
+++ b/src/main/java/dev/coms4156/project/kebabcase/controller/BuildingController.java
@@ -1,10 +1,107 @@
 package dev.coms4156.project.kebabcase.controller;
 
-import org.springframework.web.bind.annotation.GetMapping;
+import java.time.OffsetDateTime;
+import java.util.Optional;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import dev.coms4156.project.kebabcase.entity.BuildingEntity;
+import dev.coms4156.project.kebabcase.repository.BuildingRepositoryInterface;
 
 /** TODO */
 @RestController
 public class BuildingController {
+  
+  private final BuildingRepositoryInterface buildingRepository;
+
+  private final ObjectMapper objectMapper;
+
+
+  public BuildingController(
+      BuildingRepositoryInterface buildingRepository,
+      ObjectMapper objectMapper
+  ) {
+    this.buildingRepository = buildingRepository;
+    this.objectMapper = objectMapper;
+  }
+
+  @PatchMapping("/building/{id}")
+  public ResponseEntity<?> updateBuilding(
+      @PathVariable int id, 
+      @RequestParam(required = false) String address,
+      @RequestParam(required = false) String city,
+      @RequestParam(required = false) String state,
+      @RequestParam(required = false) String zipCode
+  ) {
+
+    Optional<BuildingEntity> buildingResult = buildingRepository.findById(id);
+
+    if (buildingResult.isEmpty()) {
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Building not found");
+    }
+
+    BuildingEntity building = buildingResult.get();
+
+    if (address == null && 
+        city == null && 
+        state == null && 
+        zipCode == null) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "No fields provided for update");
+    }
+
+    if (address != null) {
+        building.setAddress(address);
+    }
+    if (city != null) {
+        building.setCity(city);
+    }
+    if (state != null) {
+        building.setState(state);
+    }
+    if (zipCode != null) {
+        building.setZipCode(zipCode);
+    }
+
+    building.setModifiedDatetime(OffsetDateTime.now());
+
+    buildingRepository.save(building);
+
+    return ResponseEntity.ok("Building info has been successfully updated!");
+
+  }
+
+  @PostMapping("/building")
+  public ResponseEntity<?> createBuilding(
+      @RequestParam String address,
+      @RequestParam String city,
+      @RequestParam String state,
+      @RequestParam String zipCode
+  ) {
+
+    BuildingEntity newBuilding = new BuildingEntity();
+
+    newBuilding.setAddress(address);
+    newBuilding.setCity(city);
+    newBuilding.setState(state);
+    newBuilding.setZipCode(zipCode);
+    newBuilding.setCreatedDatetime(OffsetDateTime.now());
+    newBuilding.setModifiedDatetime(OffsetDateTime.now());
+
+    BuildingEntity savedBuilding = buildingRepository.save(newBuilding);
+
+    String response = "Building was added succesfully! Building ID: " + savedBuilding.getId().toString();
+
+    return new ResponseEntity<>(response, HttpStatus.CREATED);
+  }
+
+
 }

--- a/src/main/java/dev/coms4156/project/kebabcase/controller/BuildingController.java
+++ b/src/main/java/dev/coms4156/project/kebabcase/controller/BuildingController.java
@@ -57,19 +57,20 @@ public class BuildingController {
 
   /**
    * Updates the information of an existing building by its ID.
-   * Only the fields provided as request parameters will be updated.
-   * If no fields are provided, an HTTP 400 Bad Request will be returned.
-   * Additionally, new building features can be associated with the building.
-   * If a list of feature IDs is provided, valid features will be added to the building.
-   * If any feature ID in the list is not found, the update will still proceed, but an HTTP 206 Partial Content
-   * will be returned, along with a message listing the invalid feature IDs.
+   * <p>
+   * This method updates only the fields provided as request parameters. If no fields are provided, an HTTP 400 Bad Request will be returned.
+   * In addition to updating the building's address, city, state, and zip code, new building features can also be added, and existing features
+   * can be removed. If a list of feature IDs is provided, valid features will be added to or removed from the building. If any feature ID 
+   * in the list is not found, the update will proceed, but an HTTP 206 Partial Content will be returned, with a message listing the invalid feature IDs.
+   * </p>
    * 
    * @param id the ID of the building to update
    * @param address the new address of the building (optional)
    * @param city the new city of the building (optional)
    * @param state the new state of the building (optional)
    * @param zipCode the new zip code of the building (optional)
-   * @param features a list of feature IDs to associate with the building (optional)
+   * @param addFeatures a list of feature IDs to associate with the building (optional)
+   * @param removeFeatures a list of feature IDs to disassociate from the building (optional)
    * @return a {@link ResponseEntity} indicating the result of the update. If all updates succeed, 
    * an HTTP 200 OK is returned. If some feature IDs are invalid, an HTTP 206 Partial Content is returned 
    * with a message listing the invalid feature IDs.
@@ -206,13 +207,21 @@ public class BuildingController {
 
   /**
    * Creates a new building entity and saves it to the repository.
-   * The new building's information must be provided as request parameters.
+   * <p>
+   * The new building's information such as address, city, state, and zip code must be provided. Optionally, 
+   * a list of feature IDs can be associated with the building at the time of creation. If any feature IDs are not found, 
+   * the building will still be created, but an HTTP 206 Partial Content will be returned, listing the invalid feature IDs.
+   * Additionally, if a building with the same address, city, state, and zip code already exists, an HTTP 409 Conflict will be returned.
+   * </p>
    * 
    * @param address the address of the new building
    * @param city the city of the new building
    * @param state the state of the new building
    * @param zipCode the zip code of the new building
-   * @return a {@link ResponseEntity} containing the result of the creation and the new building's ID
+   * @param features a list of feature IDs to associate with the new building (optional)
+   * @return a {@link ResponseEntity} containing the result of the creation and the new building's ID. If any feature IDs are invalid,
+   * an HTTP 206 Partial Content is returned.
+   * @throws ResponseStatusException if a building with the same address, city, state, and zip code already exists
    */
   @PostMapping("/building")
   public ResponseEntity<?> createBuilding(

--- a/src/main/java/dev/coms4156/project/kebabcase/controller/BuildingController.java
+++ b/src/main/java/dev/coms4156/project/kebabcase/controller/BuildingController.java
@@ -86,7 +86,8 @@ public class BuildingController {
     Optional<BuildingEntity> buildingResult = buildingRepository.findById(id);
 
     if (buildingResult.isEmpty()) {
-      throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Building not found");
+      String errorMessage = "Building not found";
+      return ResponseEntity.status(HttpStatus.NOT_FOUND).body(errorMessage);
     }
 
     BuildingEntity building = buildingResult.get();
@@ -96,7 +97,8 @@ public class BuildingController {
         state == null && 
         zipCode == null &&
         features == null) {
-      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "No fields provided for update");
+      String errorMessage = "No fields provided for update";
+      return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorMessage);
     }
 
     if (address != null) {
@@ -149,7 +151,8 @@ public class BuildingController {
         zipCode == null &&
         features != null &&
         invalidFeatures.size() == features.size()) {
-      throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Could not find any of the building features requested.");
+      String errorMessage = "Could not find any of the building features requested.";
+      return ResponseEntity.status(HttpStatus.NOT_FOUND).body(errorMessage);          
     }
 
     if (!invalidFeatures.isEmpty()) {
@@ -179,6 +182,14 @@ public class BuildingController {
       @RequestParam(required = false) List<Integer> features
   ) {
 
+    /* Check if the building already exists */
+    Optional<BuildingEntity> existingBuilding = buildingRepository.findByAddressAndCityAndStateAndZipCode(address, city, state, zipCode);
+
+    if (existingBuilding.isPresent()) {
+      return ResponseEntity.status(HttpStatus.CONFLICT).body("A building with the same address already exists.");
+    }
+
+    /* Create building */
     BuildingEntity newBuilding = new BuildingEntity();
 
     newBuilding.setAddress(address);

--- a/src/main/java/dev/coms4156/project/kebabcase/controller/HousingUnitController.java
+++ b/src/main/java/dev/coms4156/project/kebabcase/controller/HousingUnitController.java
@@ -1,19 +1,23 @@
 package dev.coms4156.project.kebabcase.controller;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import dev.coms4156.project.kebabcase.entity.BuildingEntity;
-import dev.coms4156.project.kebabcase.entity.HousingUnitEntity;
-import dev.coms4156.project.kebabcase.repository.BuildingRepositoryInterface;
-import dev.coms4156.project.kebabcase.repository.HousingUnitRepositoryInterface;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import dev.coms4156.project.kebabcase.entity.BuildingEntity;
+import dev.coms4156.project.kebabcase.entity.HousingUnitEntity;
+import dev.coms4156.project.kebabcase.repository.BuildingRepositoryInterface;
+import dev.coms4156.project.kebabcase.repository.HousingUnitRepositoryInterface;
 
 /** TODO */
 @RestController
@@ -23,6 +27,9 @@ public class HousingUnitController {
   private final BuildingRepositoryInterface buildingRepository;
 
   private final ObjectMapper objectMapper;
+
+  private static final DateTimeFormatter formatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME;
+
 
   public HousingUnitController(
       HousingUnitRepositoryInterface housingUnitRepository,
@@ -56,5 +63,28 @@ public class HousingUnitController {
       Json.put("unit_number", housingUnit.getUnitNumber());
       return Json;
     }).collect(Collectors.toList());
+  }
+
+  @GetMapping("/housing-unit/{id}")
+  public ObjectNode getHousingUnit(@PathVariable int id) {
+
+    Optional<HousingUnitEntity> housingUnitRepoResult = this.housingUnitRepository.findById(id);
+
+    if (housingUnitRepoResult.isEmpty()) {
+      throw new ResponseStatusException(
+          HttpStatus.NOT_FOUND, "Housing unit with id " + id + " not found"
+      );
+    }
+
+    HousingUnitEntity unit = housingUnitRepoResult.get();
+
+    ObjectNode json = this.objectMapper.createObjectNode();
+    json.put("id", unit.getId());
+    json.put("building_id", unit.getBuilding().getId());
+    json.put("unit_number", unit.getUnitNumber());
+    json.put("created_datetime", unit.getCreatedDatetime().format(formatter));
+    json.put("modified_datetime", unit.getModifiedDatetime().format(formatter));
+
+    return json;
   }
 }

--- a/src/main/java/dev/coms4156/project/kebabcase/controller/HousingUnitController.java
+++ b/src/main/java/dev/coms4156/project/kebabcase/controller/HousingUnitController.java
@@ -65,9 +65,22 @@ public class HousingUnitController {
     }).collect(Collectors.toList());
   }
 
+  /**
+   * Retrieves a housing unit by its ID and returns its details as a JSON object.
+   * <p>
+   * This method uses the housing unit ID to search the repository for a corresponding
+   * {@link HousingUnitEntity}. If found, the housing unit's details such as ID, building ID,
+   * unit number, created date, and modified date are returned in JSON format. If the housing unit 
+   * is not found, an HTTP 404 Not Found status is returned.
+   * </p>
+   *
+   * @param id the ID of the housing unit to retrieve
+   * @return an {@link ObjectNode} containing the housing unit's details
+   * @throws ResponseStatusException if the housing unit with the given ID is not found
+   */
   @GetMapping("/housing-unit/{id}")
   public ObjectNode getHousingUnit(@PathVariable int id) {
-
+    
     Optional<HousingUnitEntity> housingUnitRepoResult = this.housingUnitRepository.findById(id);
 
     if (housingUnitRepoResult.isEmpty()) {

--- a/src/main/java/dev/coms4156/project/kebabcase/controller/HousingUnitController.java
+++ b/src/main/java/dev/coms4156/project/kebabcase/controller/HousingUnitController.java
@@ -97,7 +97,7 @@ public class HousingUnitController {
    * @throws ResponseStatusException if the housing unit with the given ID is not found
    */
   @GetMapping("/housing-unit/{id}")
-  public ObjectNode getHousingUnit(@PathVariable int id) {
+  public ResponseEntity<?> getHousingUnit(@PathVariable int id) {
     
     Optional<HousingUnitEntity> housingUnitRepoResult = this.housingUnitRepository.findById(id);
 
@@ -115,7 +115,7 @@ public class HousingUnitController {
     json.put("created_datetime", unit.getCreatedDatetime().format(formatter));
     json.put("modified_datetime", unit.getModifiedDatetime().format(formatter));
 
-    return json;
+    return ResponseEntity.ok(json);
   }
 
   /**

--- a/src/main/java/dev/coms4156/project/kebabcase/controller/HousingUnitController.java
+++ b/src/main/java/dev/coms4156/project/kebabcase/controller/HousingUnitController.java
@@ -91,11 +91,12 @@ public class HousingUnitController {
    * This method uses the housing unit ID to search the repository for a corresponding
    * {@link HousingUnitEntity}. If found, the housing unit's details such as ID, building ID,
    * unit number, created date, and modified date are returned in JSON format. If the housing unit 
-   * is not found, an HTTP 404 Not Found status is returned.
+   * is not found, an HTTP 404 Not Found status is returned with an error message.
    * </p>
    *
    * @param id the ID of the housing unit to retrieve
-   * @return an {@link ObjectNode} containing the housing unit's details
+   * @return a {@link ResponseEntity} containing the housing unit's details in an {@link ObjectNode} format,
+   *         or a 404 Not Found status if the housing unit is not found.
    * @throws ResponseStatusException if the housing unit with the given ID is not found
    */
   @GetMapping("/housing-unit/{id}")
@@ -122,19 +123,23 @@ public class HousingUnitController {
 
   /**
    * Updates the information of an existing housing unit by its ID.
-   * Specifically, it updates the unit number, the modified date, and optionally associates new features with the housing unit.
-   * 
-   * If no fields (unitNumber or features) are provided, an HTTP 400 Bad Request will be returned.
-   * If features are provided, valid features will be added to the housing unit. 
+   * Specifically, it updates the unit number, the modified date, and optionally adds or removes
+   * features associated with the housing unit. 
+   * <p>
+   * If no fields (unitNumber, addFeatures, or removeFeatures) are provided, an HTTP 400 Bad Request will be returned.
+   * If features are provided, valid features will be added to or removed from the housing unit. 
    * If any feature ID in the list is not found, the update will still proceed, but an HTTP 206 Partial Content
    * will be returned with a message listing the invalid feature IDs.
+   * </p>
    * 
    * @param id the ID of the housing unit to update
    * @param unitNumber the new unit number for the housing unit (optional)
-   * @param features a list of feature IDs to associate with the housing unit (optional)
-   * @return a {@link ResponseEntity} indicating the result of the update. If all updates succeed, 
-   * an HTTP 200 OK is returned. If some feature IDs are invalid, an HTTP 206 Partial Content is returned 
-   * with a message listing the invalid feature IDs.
+   * @param addFeatures a list of feature IDs to add to the housing unit (optional)
+   * @param removeFeatures a list of feature IDs to remove from the housing unit (optional)
+   * @return a {@link ResponseEntity} indicating the result of the update. 
+   *         If all updates succeed, an HTTP 200 OK is returned. 
+   *         If some feature IDs are invalid, an HTTP 206 Partial Content is returned 
+   *         with a message listing the invalid feature IDs.
    * @throws ResponseStatusException if the housing unit with the given ID is not found, or if no fields are provided for update
    */
   @PatchMapping("/housing-unit/{id}")
@@ -249,12 +254,16 @@ public class HousingUnitController {
   /**
    * Creates a new housing unit and associates it with an existing building.
    * The new housing unit will have the specified unit number and be linked to the building
-   * with the provided building ID.
+   * with the provided building ID. Optionally, it can also associate features with the new housing unit.
+   * 
+   * If the building ID is not found, an HTTP 404 Not Found response is returned.
+   * If a housing unit with the same unit number already exists in the building, an HTTP 409 Conflict is returned.
    * 
    * @param buildingID the ID of the building to associate the new housing unit with
    * @param unitNumber the unit number for the new housing unit
-   * @return a {@link ResponseEntity} containing a message and the new housing unit's ID
-   * @throws ResponseStatusException if the building with the provided ID is not found
+   * @param features a list of feature IDs to associate with the housing unit (optional)
+   * @return a {@link ResponseEntity} containing a message and the new housing unit's ID, or an error message if the building or housing unit cannot be found
+   * @throws ResponseStatusException if the building with the provided ID is not found or if a housing unit with the same number already exists in the building
    */
   @PostMapping("/housing-unit")
   public ResponseEntity<?> createBuilding(

--- a/src/main/java/dev/coms4156/project/kebabcase/controller/HousingUnitController.java
+++ b/src/main/java/dev/coms4156/project/kebabcase/controller/HousingUnitController.java
@@ -177,10 +177,15 @@ public class HousingUnitController {
         } else {
           HousingUnitFeatureEntity feature = featureResult.get();
 
-          unitMapFeature.setHousingUnit(unit);
-          unitMapFeature.setHousingUnitFeature(feature);
+          Optional<HousingUnitFeatureHousingUnitMappingEntity> existingMapping =
+            this.unitFeatureMappingRepository.findByHousingUnitAndHousingUnitFeature(unit, feature);
 
-          unitFeatureMappingRepository.save(unitMapFeature);
+          if (existingMapping.isEmpty()) {
+            unitMapFeature.setHousingUnit(unit);
+            unitMapFeature.setHousingUnitFeature(feature);
+
+            unitFeatureMappingRepository.save(unitMapFeature);
+          }
         }
       }
     }

--- a/src/main/java/dev/coms4156/project/kebabcase/controller/HousingUnitController.java
+++ b/src/main/java/dev/coms4156/project/kebabcase/controller/HousingUnitController.java
@@ -1,13 +1,18 @@
 package dev.coms4156.project.kebabcase.controller;
 
+import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 
@@ -100,4 +105,61 @@ public class HousingUnitController {
 
     return json;
   }
+
+
+  @PatchMapping("/housing-unit/{id}")
+  public ResponseEntity<?> updateBuilding(
+      @PathVariable int id, 
+      @RequestParam String unitNumber
+  ) {
+
+    Optional<HousingUnitEntity> unitResult = housingUnitRepository.findById(id);
+
+    if (unitResult.isEmpty()) {
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Building not found");
+    }
+
+    HousingUnitEntity unit = unitResult.get();
+
+    unit.setUnitNumber(unitNumber);
+
+    unit.setModifiedDatetime(OffsetDateTime.now());
+
+    housingUnitRepository.save(unit);
+
+    return ResponseEntity.ok("Housing unit info has been successfully updated!");
+
+  }
+
+  
+  @PostMapping("/housing-unit")
+  public ResponseEntity<?> createBuilding(
+      @RequestParam int buildingID,
+      @RequestParam String unitNumber
+  ) {
+
+    HousingUnitEntity newUnit = new HousingUnitEntity();
+
+    Optional<BuildingEntity> buildingRepoResult = this.buildingRepository.findById(buildingID);
+
+    if (buildingRepoResult.isEmpty()) {
+      throw new ResponseStatusException(
+          HttpStatus.NOT_FOUND, "Building with id " + buildingID + " not found"
+      );
+    }
+
+    BuildingEntity building = buildingRepoResult.get();
+
+    newUnit.setBuilding(building);
+    newUnit.setUnitNumber(unitNumber);
+    newUnit.setCreatedDatetime(OffsetDateTime.now());
+    newUnit.setModifiedDatetime(OffsetDateTime.now());
+
+    HousingUnitEntity savedUnit = housingUnitRepository.save(newUnit);
+
+    String response = "Housing Unit was added succesfully! Housing Unit ID: " + savedUnit.getId().toString();
+
+    return new ResponseEntity<>(response, HttpStatus.CREATED);
+  }
+
 }

--- a/src/main/java/dev/coms4156/project/kebabcase/controller/HousingUnitController.java
+++ b/src/main/java/dev/coms4156/project/kebabcase/controller/HousingUnitController.java
@@ -106,7 +106,15 @@ public class HousingUnitController {
     return json;
   }
 
-
+  /**
+   * Updates the information of an existing housing unit by its ID.
+   * Specifically, it updates the unit number and modified date.
+   * 
+   * @param id the ID of the housing unit to update
+   * @param unitNumber the new unit number for the housing unit
+   * @return a {@link ResponseEntity} indicating the result of the update
+   * @throws ResponseStatusException if the housing unit with the given ID is not found
+   */
   @PatchMapping("/housing-unit/{id}")
   public ResponseEntity<?> updateBuilding(
       @PathVariable int id, 
@@ -131,7 +139,16 @@ public class HousingUnitController {
 
   }
 
-  
+  /**
+   * Creates a new housing unit and associates it with an existing building.
+   * The new housing unit will have the specified unit number and be linked to the building
+   * with the provided building ID.
+   * 
+   * @param buildingID the ID of the building to associate the new housing unit with
+   * @param unitNumber the unit number for the new housing unit
+   * @return a {@link ResponseEntity} containing a message and the new housing unit's ID
+   * @throws ResponseStatusException if the building with the provided ID is not found
+   */
   @PostMapping("/housing-unit")
   public ResponseEntity<?> createBuilding(
       @RequestParam int buildingID,

--- a/src/main/java/dev/coms4156/project/kebabcase/repository/BuildingFeatureBuildingMappingRepositoryInterface.java
+++ b/src/main/java/dev/coms4156/project/kebabcase/repository/BuildingFeatureBuildingMappingRepositoryInterface.java
@@ -1,9 +1,16 @@
 package dev.coms4156.project.kebabcase.repository;
 
-import dev.coms4156.project.kebabcase.entity.BuildingFeatureBuildingMappingEntity;
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import dev.coms4156.project.kebabcase.entity.BuildingEntity;
+import dev.coms4156.project.kebabcase.entity.BuildingFeatureBuildingMappingEntity;
+import dev.coms4156.project.kebabcase.entity.BuildingFeatureEntity;
+
 @Repository("BuildingFeatureBuildingMappingRepository")
 public interface BuildingFeatureBuildingMappingRepositoryInterface extends JpaRepository<BuildingFeatureBuildingMappingEntity, Integer> {
+        Optional<BuildingFeatureBuildingMappingEntity> findByBuildingAndBuildingFeature(BuildingEntity building, BuildingFeatureEntity buildingFeature);
+
 }

--- a/src/main/java/dev/coms4156/project/kebabcase/repository/BuildingFeatureBuildingMappingRepositoryInterface.java
+++ b/src/main/java/dev/coms4156/project/kebabcase/repository/BuildingFeatureBuildingMappingRepositoryInterface.java
@@ -1,15 +1,36 @@
 package dev.coms4156.project.kebabcase.repository;
 
-import java.util.Optional;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
 import dev.coms4156.project.kebabcase.entity.BuildingEntity;
 import dev.coms4156.project.kebabcase.entity.BuildingFeatureBuildingMappingEntity;
 import dev.coms4156.project.kebabcase.entity.BuildingFeatureEntity;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+/**
+ * Repository interface for managing mappings between buildings and their features.
+ * <p>
+ * This interface extends {@link JpaRepository} to provide CRUD operations on 
+ * {@link BuildingFeatureBuildingMappingEntity}. It also includes a custom query 
+ * method for finding a specific mapping by building and feature.
+ * </p>
+ * 
+ * @see BuildingFeatureBuildingMappingEntity
+ * @see BuildingEntity
+ * @see BuildingFeatureEntity
+ */
 @Repository("BuildingFeatureBuildingMappingRepository")
-public interface BuildingFeatureBuildingMappingRepositoryInterface extends JpaRepository<BuildingFeatureBuildingMappingEntity, Integer> {
-  Optional<BuildingFeatureBuildingMappingEntity> findByBuildingAndBuildingFeature(BuildingEntity building, BuildingFeatureEntity buildingFeature);
+public interface BuildingFeatureBuildingMappingRepositoryInterface 
+    extends JpaRepository<BuildingFeatureBuildingMappingEntity, Integer> {
+
+  /**
+   * Finds the mapping between a building and a building feature.
+   * 
+   * @param building the building entity to find the feature mapping for
+   * @param buildingFeature the building feature entity associated with the building
+   * @return an {@link Optional} containing the mapping if found, or empty if not found
+   */
+  Optional<BuildingFeatureBuildingMappingEntity> 
+      findByBuildingAndBuildingFeature(BuildingEntity building, 
+                                          BuildingFeatureEntity buildingFeature);
 }

--- a/src/main/java/dev/coms4156/project/kebabcase/repository/BuildingFeatureBuildingMappingRepositoryInterface.java
+++ b/src/main/java/dev/coms4156/project/kebabcase/repository/BuildingFeatureBuildingMappingRepositoryInterface.java
@@ -11,6 +11,5 @@ import dev.coms4156.project.kebabcase.entity.BuildingFeatureEntity;
 
 @Repository("BuildingFeatureBuildingMappingRepository")
 public interface BuildingFeatureBuildingMappingRepositoryInterface extends JpaRepository<BuildingFeatureBuildingMappingEntity, Integer> {
-        Optional<BuildingFeatureBuildingMappingEntity> findByBuildingAndBuildingFeature(BuildingEntity building, BuildingFeatureEntity buildingFeature);
-
+  Optional<BuildingFeatureBuildingMappingEntity> findByBuildingAndBuildingFeature(BuildingEntity building, BuildingFeatureEntity buildingFeature);
 }

--- a/src/main/java/dev/coms4156/project/kebabcase/repository/BuildingRepositoryInterface.java
+++ b/src/main/java/dev/coms4156/project/kebabcase/repository/BuildingRepositoryInterface.java
@@ -1,13 +1,35 @@
 package dev.coms4156.project.kebabcase.repository;
 
+import dev.coms4156.project.kebabcase.entity.BuildingEntity;
 import java.util.Optional;
-
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import dev.coms4156.project.kebabcase.entity.BuildingEntity;
-
+/**
+ * Repository interface for managing building entities.
+ * <p>
+ * This interface extends {@link JpaRepository} to provide CRUD operations on 
+ * {@link BuildingEntity}. It also includes a custom query method for finding a 
+ * building by its address, city, state, and zip code.
+ * </p>
+ * 
+ * @see BuildingEntity
+ */
 @Repository("BuildingRepository")
 public interface BuildingRepositoryInterface extends JpaRepository<BuildingEntity, Integer> {
-  Optional<BuildingEntity> findByAddressAndCityAndStateAndZipCode(String address, String city, String state, String zipCode);
+
+  /**
+   * Finds a building by its address, city, state, and zip code.
+   * 
+   * @param address the street address of the building
+   * @param city the city where the building is located
+   * @param state the state where the building is located
+   * @param zipCode the zip code of the building
+   * @return an {@link Optional} containing the building if found, or empty if not found
+   */
+  Optional<BuildingEntity> findByAddressAndCityAndStateAndZipCode(String address, 
+                                                                      String city, 
+                                                                      String state, 
+                                                                      String zipCode);
+
 }

--- a/src/main/java/dev/coms4156/project/kebabcase/repository/BuildingRepositoryInterface.java
+++ b/src/main/java/dev/coms4156/project/kebabcase/repository/BuildingRepositoryInterface.java
@@ -1,10 +1,13 @@
 package dev.coms4156.project.kebabcase.repository;
 
-import dev.coms4156.project.kebabcase.entity.BuildingEntity;
-import dev.coms4156.project.kebabcase.entity.UserEntity;
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import dev.coms4156.project.kebabcase.entity.BuildingEntity;
+
 @Repository("BuildingRepository")
 public interface BuildingRepositoryInterface extends JpaRepository<BuildingEntity, Integer> {
+  Optional<BuildingEntity> findByAddressAndCityAndStateAndZipCode(String address, String city, String state, String zipCode);
 }

--- a/src/main/java/dev/coms4156/project/kebabcase/repository/HousingUnitFeatureHousingUnitMappingRepositoryInterface.java
+++ b/src/main/java/dev/coms4156/project/kebabcase/repository/HousingUnitFeatureHousingUnitMappingRepositoryInterface.java
@@ -11,5 +11,5 @@ import dev.coms4156.project.kebabcase.entity.HousingUnitFeatureHousingUnitMappin
 
 @Repository("HousingUnitFeatureHousingUnitMappingRepository")
 public interface HousingUnitFeatureHousingUnitMappingRepositoryInterface extends JpaRepository<HousingUnitFeatureHousingUnitMappingEntity, Integer> {
-        Optional<HousingUnitFeatureHousingUnitMappingEntity> findByHousingUnitAndHousingUnitFeature(HousingUnitEntity housingUnit, HousingUnitFeatureEntity housingUnitFeature);
+  Optional<HousingUnitFeatureHousingUnitMappingEntity> findByHousingUnitAndHousingUnitFeature(HousingUnitEntity housingUnit, HousingUnitFeatureEntity housingUnitFeature);
 }

--- a/src/main/java/dev/coms4156/project/kebabcase/repository/HousingUnitFeatureHousingUnitMappingRepositoryInterface.java
+++ b/src/main/java/dev/coms4156/project/kebabcase/repository/HousingUnitFeatureHousingUnitMappingRepositoryInterface.java
@@ -9,7 +9,31 @@ import dev.coms4156.project.kebabcase.entity.HousingUnitEntity;
 import dev.coms4156.project.kebabcase.entity.HousingUnitFeatureEntity;
 import dev.coms4156.project.kebabcase.entity.HousingUnitFeatureHousingUnitMappingEntity;
 
+/**
+ * Repository interface for managing mappings between housing units and their associated features.
+ * <p>
+ * This interface extends {@link JpaRepository} to provide CRUD operations on the 
+ * {@link HousingUnitFeatureHousingUnitMappingEntity}. It also includes a custom query method 
+ * for finding mappings by housing unit and feature.
+ * </p>
+ * 
+ * @see HousingUnitFeatureHousingUnitMappingEntity
+ * @see HousingUnitEntity
+ * @see HousingUnitFeatureEntity
+ */
 @Repository("HousingUnitFeatureHousingUnitMappingRepository")
-public interface HousingUnitFeatureHousingUnitMappingRepositoryInterface extends JpaRepository<HousingUnitFeatureHousingUnitMappingEntity, Integer> {
-  Optional<HousingUnitFeatureHousingUnitMappingEntity> findByHousingUnitAndHousingUnitFeature(HousingUnitEntity housingUnit, HousingUnitFeatureEntity housingUnitFeature);
+public interface HousingUnitFeatureHousingUnitMappingRepositoryInterface 
+      extends JpaRepository<HousingUnitFeatureHousingUnitMappingEntity, Integer> {
+
+  /**
+   * Finds a mapping between a housing unit and a feature.
+   * 
+   * @param housingUnit the housing unit entity
+   * @param housingUnitFeature the feature entity associated with the housing unit
+   * @return an {@link Optional} containing the found mapping or empty if not found
+   */
+  Optional<HousingUnitFeatureHousingUnitMappingEntity> 
+      findByHousingUnitAndHousingUnitFeature(HousingUnitEntity housingUnit, 
+                                                HousingUnitFeatureEntity housingUnitFeature);
+
 }

--- a/src/main/java/dev/coms4156/project/kebabcase/repository/HousingUnitFeatureHousingUnitMappingRepositoryInterface.java
+++ b/src/main/java/dev/coms4156/project/kebabcase/repository/HousingUnitFeatureHousingUnitMappingRepositoryInterface.java
@@ -1,10 +1,15 @@
 package dev.coms4156.project.kebabcase.repository;
 
-import dev.coms4156.project.kebabcase.entity.HousingUnitFeatureHousingUnitMappingEntity;
-import dev.coms4156.project.kebabcase.entity.UserEntity;
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import dev.coms4156.project.kebabcase.entity.HousingUnitEntity;
+import dev.coms4156.project.kebabcase.entity.HousingUnitFeatureEntity;
+import dev.coms4156.project.kebabcase.entity.HousingUnitFeatureHousingUnitMappingEntity;
+
 @Repository("HousingUnitFeatureHousingUnitMappingRepository")
 public interface HousingUnitFeatureHousingUnitMappingRepositoryInterface extends JpaRepository<HousingUnitFeatureHousingUnitMappingEntity, Integer> {
+        Optional<HousingUnitFeatureHousingUnitMappingEntity> findByHousingUnitAndHousingUnitFeature(HousingUnitEntity housingUnit, HousingUnitFeatureEntity housingUnitFeature);
 }

--- a/src/main/java/dev/coms4156/project/kebabcase/repository/HousingUnitRepositoryInterface.java
+++ b/src/main/java/dev/coms4156/project/kebabcase/repository/HousingUnitRepositoryInterface.java
@@ -1,16 +1,41 @@
 package dev.coms4156.project.kebabcase.repository;
 
+import dev.coms4156.project.kebabcase.entity.BuildingEntity;
+import dev.coms4156.project.kebabcase.entity.HousingUnitEntity;
 import java.util.List;
 import java.util.Optional;
-
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import dev.coms4156.project.kebabcase.entity.BuildingEntity;
-import dev.coms4156.project.kebabcase.entity.HousingUnitEntity;
-
+/**
+ * Repository interface for managing housing unit entities within buildings.
+ * <p>
+ * This interface extends {@link JpaRepository} to provide CRUD operations on the 
+ * {@link HousingUnitEntity}. It also includes custom query methods for finding housing 
+ * units by building and by building and unit number.
+ * </p>
+ * 
+ * @see HousingUnitEntity
+ * @see BuildingEntity
+ */
 @Repository("HousingUnitRepository")
 public interface HousingUnitRepositoryInterface extends JpaRepository<HousingUnitEntity, Integer> {
+
+  /**
+   * Retrieves a list of housing units associated with a specific building.
+   * 
+   * @param building the building entity to find housing units for
+   * @return a list of {@link HousingUnitEntity} associated with the building
+   */
   List<HousingUnitEntity> findByBuilding(BuildingEntity building);
-  Optional<HousingUnitEntity> findByBuildingAndUnitNumber(BuildingEntity building, String unitNumber);
+
+  /**
+   * Finds a housing unit by its building and unit number.
+   * 
+   * @param building the building entity
+   * @param unitNumber the unit number of the housing unit
+   * @return an {@link Optional} containing the housing unit if found, or empty if not found
+   */
+  Optional<HousingUnitEntity> 
+      findByBuildingAndUnitNumber(BuildingEntity building, String unitNumber);
 }

--- a/src/main/java/dev/coms4156/project/kebabcase/repository/HousingUnitRepositoryInterface.java
+++ b/src/main/java/dev/coms4156/project/kebabcase/repository/HousingUnitRepositoryInterface.java
@@ -1,13 +1,16 @@
 package dev.coms4156.project.kebabcase.repository;
 
-import dev.coms4156.project.kebabcase.entity.BuildingEntity;
-import dev.coms4156.project.kebabcase.entity.HousingUnitEntity;
-import dev.coms4156.project.kebabcase.entity.UserEntity;
 import java.util.List;
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+
+import dev.coms4156.project.kebabcase.entity.BuildingEntity;
+import dev.coms4156.project.kebabcase.entity.HousingUnitEntity;
 
 @Repository("HousingUnitRepository")
 public interface HousingUnitRepositoryInterface extends JpaRepository<HousingUnitEntity, Integer> {
   List<HousingUnitEntity> findByBuilding(BuildingEntity building);
+  Optional<HousingUnitEntity> findByBuildingAndUnitNumber(BuildingEntity building, String unitNumber);
 }


### PR DESCRIPTION
Tested all of them manually on Postman (TODO: create unit tests).
The PATCH endpoints are also really long, so maybe need to break it down ??

**GET /housing-unit/{id}**
- Returns a JSON object with only the info in the housing unit table
- _Do we also want to include the unit/building features in the returned JSON object?_

**POST /housing-unit and /building**
- HTTP Responses:
  - NOT_FOUND: building ID doesn't exist for creating new housing unit
  - CONFLICT: building/unit to create already exists
  - PARTIAL_CONTENT: user provided features that didn't exists (will still create based on other info provided)
  - CREATED: unit/building created and all info provided is included
- All parameters are mandatory except the features _(does this work with everyone?)_

**PATCH /housing-unit/{id} and /building/{id}**
- HTTP Responses:
  - NOT_FOUND: building/unit doesn't exist, none of the feature IDs were found
  - BAD_REQUEST: all parameters are not required so this checks if user gives at least one field to update
  - PARTIAL_CONTENT: building/unit updated but couldn't find some of the feature IDs
  - CREATED: unit/building created and all info provided is included